### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,13 +1,11 @@
 # This bash script uses git to sync changes between a local and remote GitHub repository on branch 'main'.
 # It assumes that the remote repository is already set up and that the local repository is already cloned.
 
-# Steps: pull changes from remote repository, stage all changes, commit changes with message 'Updated', push changes to remote repository on branch 'main'.
-
 # Pull changes from remote repository
 git pull origin main
 
 # Stage all changes
-git stage .
+git add .
 
 # Commit changes with message 'Updated'
 git commit -m "Updated"


### PR DESCRIPTION
This pull request includes a minor change to the `sync-repo.sh` script to improve clarity and correctness.

* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L4-R8): Replaced the incorrect `git stage .` command with the correct `git add .` command.